### PR TITLE
Simplification of xml names and define output settings

### DIFF
--- a/spim_registration/timelapse/Snakefile
+++ b/spim_registration/timelapse/Snakefile
@@ -168,7 +168,7 @@ rule resave_hdf5:
         shell(part_string) 
        	       	
 rule registration:
-    input:  rules.resave_hdf5.output, expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]) # "{xml_base}-{file_id}-00.h5"
+    input:  rules.resave_hdf5.output, rules.hdf5_xml.output # expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]) 
     output: temp("{xml_base}.job_{file_id,\d+}.xml") #, "{xml_base}-{file_id,\d+}-00.h5_registered", 
     log: "logs/c_{xml_base}-{file_id}-registration.log"
     run:

--- a/spim_registration/timelapse/Snakefile
+++ b/spim_registration/timelapse/Snakefile
@@ -36,7 +36,7 @@ rule resave_prepared:
 # defining xml for czi dataset
 rule define_xml_czi:
     input: config["common"]["first_czi"]
-    output: config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml"
+    output: temp(config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml")
     log: "logs/a1_define_xml_czi.log"
     run: 
         cmd_string = produce_string(
@@ -67,7 +67,7 @@ rule define_xml_czi:
 # defining xml for tif dataset
 rule define_xml_tif:
     input: glob.glob(re.sub("{{.}}","*", config["common"]['image_file_pattern'])) #replaces all occurrences of {{a}} (a can be any character) by * to use the string for globbing
-    output: config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml"
+    output: temp(config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml")
     log: "logs/a2_define_xml_tif.log"
     run:
         cmd_string = produce_string(
@@ -107,7 +107,7 @@ ruleorder: define_xml_czi > define_xml_tif
 # create mother .xml/.h5
 rule hdf5_xml:
     input: config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml" 
-    output: expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]), [ item+"_xml" for item in datasets ]
+    output: expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]), temp([ item+"_xml" for item in datasets ])
     log: "logs/b1_hdf5_xml.log"
     run:
         part_string = produce_string(
@@ -137,8 +137,8 @@ rule hdf5_xml:
 
 # resave  .czi/.tif dataset as hdf5	
 rule resave_hdf5:
-    input: rules.hdf5_xml.output #, config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml"
-    output: "{xml_base}-{file_id,\d+}-00.h5", "{xml_base}-{file_id,\d+}-00.h5_hdf5"
+    input: "{xml_base}-{file_id,\d+}-00.h5_xml", config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml"
+    output: "{xml_base}-{file_id,\d+}-00.h5", temp("{xml_base}-{file_id,\d+}-00.h5_hdf5")
     log: "logs/b2_resave_hdf5-{file_id}.log"
     run:
         part_string = produce_string(
@@ -167,7 +167,7 @@ rule resave_hdf5:
         shell(part_string) 
        	       	
 rule registration:
-    input:  "{xml_base}-{file_id}-00.h5" #, expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]) 
+    input: rules.resave_hdf5.output, [ item+"_hdf5" for item in datasets ], expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]) 
     output: temp("{xml_base}.job_{file_id,\d+}.xml") #, "{xml_base}-{file_id,\d+}-00.h5_registered", 
     log: "logs/c_{xml_base}-{file_id}-registration.log"
     run:
@@ -485,7 +485,7 @@ rule hdf5_xml_output:
         shell(part_string)
 
 rule resave_hdf5_output:
-    input: rules.hdf5_xml_output.output, config["common"]["hdf5_xml_filename"].strip('\"') + "_output_define.xml"
+    input: "{xml_base}-{file_id,\d+}-00.h5_output", config["common"]["hdf5_xml_filename"].strip('\"') + "_output_define.xml"
     output: temp("{xml_base}-{file_id,\d+}-00.h5_output_hdf5")
     log: "logs/f3_resave_output-{file_id}.log"
     run:

--- a/spim_registration/timelapse/Snakefile
+++ b/spim_registration/timelapse/Snakefile
@@ -36,7 +36,7 @@ rule resave_prepared:
 # defining xml for czi dataset
 rule define_xml_czi:
     input: config["common"]["first_czi"]
-    output: temp(config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml")
+    output: config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml"
     log: "logs/a1_define_xml_czi.log"
     run: 
         cmd_string = produce_string(
@@ -67,7 +67,7 @@ rule define_xml_czi:
 # defining xml for tif dataset
 rule define_xml_tif:
     input: glob.glob(re.sub("{{.}}","*", config["common"]['image_file_pattern'])) #replaces all occurrences of {{a}} (a can be any character) by * to use the string for globbing
-    output: temp(config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml")
+    output: config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml"
     log: "logs/a2_define_xml_tif.log"
     run:
         cmd_string = produce_string(
@@ -107,8 +107,7 @@ ruleorder: define_xml_czi > define_xml_tif
 # create mother .xml/.h5
 rule hdf5_xml:
     input: config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml" 
-    output: expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]),
-            temp([ item+"_xml" for item in datasets ])
+    output: expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]), [ item+"_xml" for item in datasets ]
     log: "logs/b1_hdf5_xml.log"
     run:
         part_string = produce_string(
@@ -138,8 +137,8 @@ rule hdf5_xml:
 
 # resave  .czi/.tif dataset as hdf5	
 rule resave_hdf5:
-    input: rules.hdf5_xml.output, config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml"
-    output: "{xml_base}-{file_id,\d+}-00.h5", temp("{xml_base}-{file_id,\d+}-00.h5_hdf5")
+    input: rules.hdf5_xml.output #, config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml"
+    output: "{xml_base}-{file_id,\d+}-00.h5", "{xml_base}-{file_id,\d+}-00.h5_hdf5"
     log: "logs/b2_resave_hdf5-{file_id}.log"
     run:
         part_string = produce_string(
@@ -168,7 +167,7 @@ rule resave_hdf5:
         shell(part_string) 
        	       	
 rule registration:
-    input:  rules.resave_hdf5.output, rules.hdf5_xml.output # expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]) 
+    input:  "{xml_base}-{file_id}-00.h5" #, expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]) 
     output: temp("{xml_base}.job_{file_id,\d+}.xml") #, "{xml_base}-{file_id,\d+}-00.h5_registered", 
     log: "logs/c_{xml_base}-{file_id}-registration.log"
     run:

--- a/spim_registration/timelapse/Snakefile
+++ b/spim_registration/timelapse/Snakefile
@@ -182,7 +182,7 @@ rule registration:
 	-Dreg_process_illumination={reg_process_illumination} \
 	-Dreg_process_angle={reg_process_angle} \
 	-Dchannels={channels} \
-	-Dreg_processing_channel={reg_processing_channel} \
+	-Dreg_processing_channel={source_channel} \
         -Dlabel_interest_points={label_interest_points} \
         -Dtype_of_registration={type_of_registration} \
         -Dtype_of_detection={type_of_detection} \
@@ -284,8 +284,8 @@ rule duplicate_transformations:
 	-Dprocess_timepoint_timelapse={timelapse_process_timepoints} \
 	-Dprocess_illumination={reg_process_illumination} \
 	-Dprocess_angle={reg_process_angle} \
-	-Dsource_dublication={source_dublication} \
-	-Dtarget_dublication={target_dublication} \
+	-Dsource_dublication={source_channel} \
+	-Dtarget_dublication={target_channel} \
 	-Dduplicate_which_transformations={duplicate_which_transformations} \
         -- --no-splash {path_bsh}""",     	
                                     config["common"],

--- a/spim_registration/timelapse/Snakefile
+++ b/spim_registration/timelapse/Snakefile
@@ -342,15 +342,16 @@ rule fusion:
         shell(cmd_string)
 
 rule external_transform:
-    input: rules.timelapse.output, merged_xml="{xml_base}_merge.xml"
-    output: temp(rules.timelapse.output[0] + "_external_trafo")
+    input: rules.timelapse.output[0], merged_xml="{xml_base}_merge.xml" #rules.timelapse.output, merged_xml="{xml_base}_merge.xml"
+    output: temp(rules.timelapse.output[0] + "_transform")
     log: "logs/e2_external_transform.log"
     run:
         cmd_string = produce_string(
         	"""{fiji-prefix} {fiji-app} \
         -Dimage_file_directory={jdir} \
 	-Dmerged_xml={merged_xml_file} \
-	-Dchannel_setting={channel_setting} \
+	-Dillumination={illumination} \
+	-Dchannel_setting={channels} \
 	-Dtransform_angle={transform_angle} \
 	-Dtransform_channel={transform_channel} \
 	-Dtransform_illumination={transform_illumination} \
@@ -370,7 +371,7 @@ rule external_transform:
         shell(cmd_string)
 
 rule deconvolution:
-    input: [ str("{xml_base}_merge.xml_" + config["common"]["transformation_switch"] ) ], "{xml_base}-{file_id,\d+}-00.h5", merged_xml="{xml_base}_merge.xml" # rules.timelapse.output, "{xml_base}-{file_id,\d+}-00.h5", merged_xml="{xml_base}_merge.xml" # rules.external_transform.output, "{xml_base}-{file_id,\d+}-00.h5", merged_xml="{xml_base}_merge.xml"
+    input: [ str("{xml_base}_merge.xml_" + config["common"]["transformation_switch"] + config["common"]["external_trafo_switch"] ) ], "{xml_base}-{file_id,\d+}-00.h5", merged_xml="{xml_base}_merge.xml" # rules.timelapse.output, "{xml_base}-{file_id,\d+}-00.h5", merged_xml="{xml_base}_merge.xml" # rules.external_transform.output, "{xml_base}-{file_id,\d+}-00.h5", merged_xml="{xml_base}_merge.xml"
     output: temp("{xml_base}-{file_id,\d+}-00.h5_deconvolution")
     log: "logs/e2_{xml_base}-{file_id,\d+}-00-deconvolution.log"
     run:
@@ -417,7 +418,7 @@ rule deconvolution:
         shell(cmd_string)
 
 rule define_output:
-    input: glob.glob('TP*'), [ item + "_" + config["common"]["fusion_switch"] for item in datasets ]
+    input: glob.glob('TP*')#, [ item + "_" + config["common"]["fusion_switch"] for item in datasets ]
     output: temp(config["common"]["hdf5_xml_filename"].strip('\"') + "_output_define.xml")
     log: "logs/f1_define_output.log"
     run:

--- a/spim_registration/timelapse/Snakefile
+++ b/spim_registration/timelapse/Snakefile
@@ -418,7 +418,7 @@ rule deconvolution:
         shell(cmd_string)
 
 rule define_output:
-    input: glob.glob('TP*')#, [ item + "_" + config["common"]["fusion_switch"] for item in datasets ]
+    input: glob.glob('TP*'), [ item + "_" + config["common"]["fusion_switch"] for item in datasets ]
     output: temp(config["common"]["hdf5_xml_filename"].strip('\"') + "_output_define.xml")
     log: "logs/f1_define_output.log"
     run:

--- a/spim_registration/timelapse/Snakefile
+++ b/spim_registration/timelapse/Snakefile
@@ -36,7 +36,7 @@ rule resave_prepared:
 # defining xml for czi dataset
 rule define_xml_czi:
     input: config["common"]["first_czi"]
-    output: temp(config["common"]["first_xml_filename"] + ".xml")
+    output: temp(config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml")
     log: "logs/a1_define_xml_czi.log"
     run: 
         cmd_string = produce_string(
@@ -57,6 +57,7 @@ rule define_xml_czi:
 	   config["common"],
 	   config["define_xml_czi"],
 	   jdir=JOBDIR,
+	   first_xml_filename=config["common"]["hdf5_xml_filename"].strip('\"') + "_first",
 	   path_bsh=config["common"]["bsh_directory"] + config["define_xml_czi"]["bsh_file"])
         cmd_string += " > {log} 2>&1"
         shell(cmd_string)
@@ -66,7 +67,7 @@ rule define_xml_czi:
 # defining xml for tif dataset
 rule define_xml_tif:
     input: glob.glob(re.sub("{{.}}","*", config["common"]['image_file_pattern'])) #replaces all occurrences of {{a}} (a can be any character) by * to use the string for globbing
-    output: temp(config["common"]["first_xml_filename"] + ".xml")
+    output: temp(config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml")
     log: "logs/a2_define_xml_tif.log"
     run:
         cmd_string = produce_string(
@@ -93,6 +94,7 @@ rule define_xml_tif:
 	   config["common"],
 	   config["define_xml_tif"],
 	   jdir=JOBDIR,
+	   first_xml_filename=config["common"]["hdf5_xml_filename"].strip('\"') + "_first",
 	   path_bsh=config["common"]["bsh_directory"] + config["define_xml_tif"]["bsh_file"],
            timepoints="0-"+str(int(config["common"]["ntimepoints"])-1)
         )
@@ -104,7 +106,7 @@ ruleorder: define_xml_czi > define_xml_tif
 
 # create mother .xml/.h5
 rule hdf5_xml:
-    input: config["common"]["first_xml_filename"] + ".xml" 
+    input: config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml" 
     output: expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]),
             temp([ item+"_xml" for item in datasets ])
     log: "logs/b1_hdf5_xml.log"
@@ -127,6 +129,7 @@ rule hdf5_xml:
            config["common"],
            config["resave_hdf5"],
            jdir=JOBDIR,
+           first_xml_filename=config["common"]["hdf5_xml_filename"].strip('\"') + "_first",
            path_bsh=config["common"]["bsh_directory"] + config["resave_hdf5"]["bsh_file"])
 
         part_string += " > {log} 2>&1 && touch {output}"
@@ -135,7 +138,7 @@ rule hdf5_xml:
 
 # resave  .czi/.tif dataset as hdf5	
 rule resave_hdf5:
-    input: rules.hdf5_xml.output, config["common"]["first_xml_filename"] + ".xml"
+    input: rules.hdf5_xml.output, config["common"]["hdf5_xml_filename"].strip('\"') + "_first.xml"
     output: "{xml_base}-{file_id,\d+}-00.h5", temp("{xml_base}-{file_id,\d+}-00.h5_hdf5")
     log: "logs/b2_resave_hdf5-{file_id}.log"
     run:
@@ -157,6 +160,7 @@ rule resave_hdf5:
            config["common"],
            config["resave_hdf5"],
            jdir=JOBDIR,
+           first_xml_filename=config["common"]["hdf5_xml_filename"].strip('\"') + "_first",
            path_bsh=config["common"]["bsh_directory"] + config["resave_hdf5"]["bsh_file"],
            input_xml_base="{wildcards.xml_base}",
            job_number=int(wildcards.file_id)+1) 
@@ -414,16 +418,17 @@ rule deconvolution:
         shell(cmd_string)
 
 rule define_output:
-    input: glob.glob('TP*'), [ item + "_" + config["common"]["fusion_switch"] for item in datasets ]
-    output: temp(config["common"]["output_xml"].strip('\"') + ".xml")
+    input: glob.glob('TP*')#, [ item + "_" + config["common"]["fusion_switch"] for item in datasets ]
+    output: temp(config["common"]["hdf5_xml_filename"].strip('\"') + "_output_define.xml")
     log: "logs/f1_define_output.log"
     run:
         cmd_string = produce_string(
         	"""{fiji-prefix} {fiji-app} \
         -Dimage_file_directory={jdir} \
-        -Dtimepoints={output_timepoints} \
-        -Dchannels={output_channels} \
-        -Dimage_file_pattern={output_image_file_pattern} \
+        -Dntimepoints={ntimepoints} \
+        -Dangles={angles} \
+        -Dchannels={channels} \
+        -Dillumination={illumination} \
         -Dmanual_calibration_output={manual_calibration_output} \
         -Dpixel_distance_x={output_pixel_distance_x} \
         -Dpixel_distance_y={output_pixel_distance_y} \
@@ -432,7 +437,6 @@ rule define_output:
        	-Dxml_filename={output_xml} \
         -Dtype_of_dataset={output_type_of_dataset} \
         -Dmultiple_timepoints={output_multiple_timepoints} \
-        -Dmultiple_channels={output_multiple_channels} \
         -Dmultiple_illumination_directions={output_illumination_directions} \
         -Dmultiple_angles={output_multiple_angles} \
         -Dimglib_container={output_imglib_container} \
@@ -440,6 +444,7 @@ rule define_output:
 	config["common"],
 	config["hdf5_output"],
 	jdir=JOBDIR,
+	output_xml=config["common"]["hdf5_xml_filename"].strip('\"') + "_output_define",
 	path_bsh=config["common"]["bsh_directory"] + config["hdf5_output"]["bsh_file_define"])
 	
 	cmd_string +=" > {log} 2>&1"
@@ -447,8 +452,8 @@ rule define_output:
 
 # create mother .xml/.h5
 rule hdf5_xml_output:
-    input: config["common"]["output_xml"].strip('\"') + ".xml"
-    output: expand("{dataset}.{suffix}",dataset=[ config["common"]["output_hdf5_xml"].strip('\"')], suffix=["xml","h5"]),
+    input: config["common"]["hdf5_xml_filename"].strip('\"') + "_output_define.xml"
+    output: expand("{dataset}.{suffix}",dataset=[ config["common"]["fusion_switch"].strip('\"') + "_" + config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]),
     	    temp([ item+"_output" for item in datasets ])
     log: "logs/f2_output_hdf5_xml.log"
     run:
@@ -473,13 +478,15 @@ rule hdf5_xml_output:
            config["hdf5_output"],
            config["resave_hdf5"],
            jdir=JOBDIR,
+           output_xml=config["common"]["hdf5_xml_filename"].strip('\"') + "_output_define",
+           output_hdf5_xml=config["common"]["fusion_switch"].strip('\"') + "_" + config["common"]["hdf5_xml_filename"].strip('\"'),
            path_bsh=config["common"]["bsh_directory"] + config["hdf5_output"]["bsh_file_hdf5"])
 
         part_string += " > {log} 2>&1 && touch {output}"
         shell(part_string)
 
 rule resave_hdf5_output:
-    input: rules.hdf5_xml_output.output, config["common"]["output_xml"].strip('\"') + ".xml"
+    input: rules.hdf5_xml_output.output, config["common"]["hdf5_xml_filename"].strip('\"') + "_output_define.xml"
     output: temp("{xml_base}-{file_id,\d+}-00.h5_output_hdf5")
     log: "logs/f3_resave_output-{file_id}.log"
     run:
@@ -504,6 +511,8 @@ rule resave_hdf5_output:
            config["hdf5_output"],
            config["resave_hdf5"],
            jdir=JOBDIR,
+           output_xml=config["common"]["hdf5_xml_filename"].strip('\"') + "_output_define",
+           output_hdf5_xml=config["common"]["fusion_switch"].strip('\"') + "_" + config["common"]["hdf5_xml_filename"].strip('\"'),
            path_bsh=config["common"]["bsh_directory"] + config["hdf5_output"]["bsh_file_hdf5"],
            input_xml_base="{wildcards.xml_base}",
            job_number=int(wildcards.file_id)+1) 
@@ -512,7 +521,7 @@ rule resave_hdf5_output:
        	       
 
 rule distclean:
-    params : glob.glob(config["common"]["hdf5_xml_filename"].strip('\"')+"*"), glob.glob(config["common"]["first_xml_filename"].strip('\"')+"*"), glob.glob("*registered"), glob.glob("*_fusion"), glob.glob("*_timelapse"), glob.glob("*log"), glob.glob("*_hdf5"), glob.glob("*_deconvolved"), glob.glob("*.xml~*"),"interestpoints", glob.glob("*empty"), expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]), glob.glob("*_output_hdf5"), glob.glob("*_output"), glob.glob("*.h5"), glob.glob("*.xml")
+    params : glob.glob(config["common"]["hdf5_xml_filename"].strip('\"')+"*"), glob.glob("*registered"), glob.glob("*_fusion"), glob.glob("*_timelapse"), glob.glob("*log"), glob.glob("*_hdf5"), glob.glob("*_deconvolved"), glob.glob("*.xml~*"),"interestpoints", glob.glob("*empty"), expand("{dataset}.{suffix}",dataset=[ config["common"]["hdf5_xml_filename"].strip('\"')], suffix=["xml","h5"]), glob.glob("*_output_hdf5"), glob.glob("*_output"), glob.glob("*.h5"), glob.glob("*.xml")
    
     message : os.path.abspath(os.path.curdir) + ": rm -rf {params}"
     shell : "rm -rf {params}"

--- a/spim_registration/timelapse/cluster.json
+++ b/spim_registration/timelapse/cluster.json
@@ -17,7 +17,7 @@
 
     "registration" :
     {
-        "lsf_extra" : "-n 2 -R \"span[hosts=1] rusage[mem=20000]\""
+        "lsf_extra" : "-n 3 -R \"span[hosts=1] rusage[mem=20000]\""
     },
     
     "timelapse" : 
@@ -43,6 +43,6 @@
     
     "resave_hdf5_output" :
     {
-	"lsf_extra" : "-n 2 -R \"span[hosts=1] rusage[mem=50000]\""
+	"lsf_extra" : "-n 2 -R \"span[hosts=1] rusage[mem=5000]\""
     }
 }

--- a/spim_registration/timelapse/cluster.json
+++ b/spim_registration/timelapse/cluster.json
@@ -12,17 +12,17 @@
 
     "resave_hdf5" :	
     {
- 	"lsf_extra" : "-n 2 -R \"span[hosts=1] rusage[mem=50000]\""
+ 	"lsf_extra" : "-n 2 -R \"span[hosts=1] rusage[mem=5000]\""
     },
 
     "registration" :
     {
-        "lsf_extra" : "-n 2 -R \"span[hosts=1] rusage[mem=100000]\""
+        "lsf_extra" : "-n 2 -R \"span[hosts=1] rusage[mem=20000]\""
     },
     
     "timelapse" : 
     {
-    	"lsf_extra" : "-n 6 -R \"span[hosts=1] rusage[mem=100000]\""
+    	"lsf_extra" : "-n 6 -R \"span[hosts=1] rusage[mem=20000]\""
     },
 
     "external_transfrom" :

--- a/spim_registration/timelapse/config.yaml
+++ b/spim_registration/timelapse/config.yaml
@@ -39,7 +39,7 @@ common: {
   # 
   # xml file name without .xml suffix
   # ============================================================================
-  hdf5_xml_filename: '"Dpse_Dip3_VK33"', # Name of .xml file for the hdf5 data after resave_hdf5
+  hdf5_xml_filename: '"single"', # Name of .xml file for the hdf5 data after resave_hdf5
   # .xml file names for output
   #output_xml: '"fused_Dpse_Dip3_VK33"',
   #output_hdf5_xml: '"hdf5_fused_Dpse_Dip3_VK33"',
@@ -54,13 +54,13 @@ common: {
   #          pixel size
   # ============================================================================
   ntimepoints: 2,        # number of timepoints of dataset
-  angles: "1,2,3,4,5",   # angles "0,72,144,216,288"
+  angles: "0,72,144,216,288",   # angles "0,72,144,216,288"
   channels: "green",     # channels, for tif numeric!
   illumination: "0",     # illuminations
   # ----------------------------------------------------------------------------
   # For .czi datasets
   # master .czi file
-  first_czi: "2015-04-01_LZ2_Stock46.czi", 
+  first_czi: "2015-02-21_LZ1_Stock68_3.czi", 
   # ----------------------------------------------------------------------------
   # For .tif datasets
   # file pattern of .tif files:
@@ -83,8 +83,8 @@ common: {
   #
   # Dual channel 1 Channel contains the beads: which channel contains the beads?
   # Ignore if Single Channel or Dual Channel both channels contain beads
-  reg_processing_channel: '"green"',
-  #
+  source_channel: "red", # channel that contains the beads
+  target_channel: "green", # channel without beads
   # reg_interest_points_channel:
   # Single Channel: '"beads"'
   # Dual Channel: '"beads,beads"'
@@ -116,13 +116,13 @@ common: {
   # Options: downsampling
   #          Cropping parameters based on full resolution
   # ============================================================================
-  downsample: '1',    # set downsampling
-  minimal_x: '237',   # Cropping parameters of full resolution
+  downsample: '2',    # set downsampling
+  minimal_x: '190',   # Cropping parameters of full resolution
   minimal_y: '-16',
-  minimal_z: '-292',
-  maximal_x: '1041',
-  maximal_y: '1853',
-  maximal_z: '509',
+  minimal_z: '-348',
+  maximal_x: '1019',
+  maximal_y: '1941',
+  maximal_z: '486',
   # ============================================================================
   # Multiview deconvolution
   #
@@ -132,12 +132,12 @@ common: {
   #          Channel settings for deconvolution
   # ============================================================================
   iterations: '1',        # number of iterations
-  minimal_x_deco: '237',  # Cropping parameters: take downsampling into account
+  minimal_x_deco: '190',  # Cropping parameters: take downsampling into account
   minimal_y_deco: '-16',
-  minimal_z_deco: '-292',
-  maximal_x_deco: '1041',
-  maximal_y_deco: '1853',
-  maximal_z_deco: '509',
+  minimal_z_deco: '-348',
+  maximal_x_deco: '1019',
+  maximal_y_deco: '1941',
+  maximal_z_deco: '486',
   #
   # Channel settings for deconvolution
   # Single Channel: '"beads"'
@@ -254,8 +254,6 @@ dublicate_transformations: {
   # If dual channel processing and only one channel contains beads
   # this allows you to dublicate the transformation for the 
   # channel that does not contain beas
-  source_dublication: "red",  # source channel
-  target_dublication: "green", # target channel
   duplicate_which_transformations: '"Replace all transformations"', # mode of dublication
   bsh_file: "dublicate_transformations.bsh" # .bsh script for dublication
   }

--- a/spim_registration/timelapse/config.yaml
+++ b/spim_registration/timelapse/config.yaml
@@ -4,8 +4,6 @@ common: {
   # yaml example file for single channel processing
   #
   # General settings for processing
-  # 2015-04-01_LZ2_Stock46
-  # Dpse_Dip3_VK33
   #
   # ============================================================================
   # directory that contains the bean shell scripts and Snakefile
@@ -17,33 +15,32 @@ common: {
   fiji-prefix: "/sw/users/schmied/packages/xvfb-run -a",       # calls xvfb for Fiji headless mode
   sysconfcpus: "sysconfcpus -n",
   # ============================================================================
-  #   Processing switches
+  # Processing switches
   # Description: Use switches to decide which processing steps you need:
   #
   # Options:
-  # transformation_switch: "timelapse" standard processing
-  # after timelapse registration directly goes into fusion, timelapse_duplicate
-  # "timelapse_duplicate" for dual channel processing one channel contains the beads
+  #           transformation_switch: "timelapse",
+  #           goes directly into fusion after timelapse registration
   #
-  # Switches between content based fusion and deconvoltion
-  # "deconvolution" > for deconvolution
-  # "fusion" > for content based fusion
+  #           transformation_switch: "timelapse_duplicate",
+  #           for dual channel processing one channel contains the beads
+  #           dublicates the transformation from the source channel to the 
+  #           target channel
+  #
+  #           Switches between content based fusion and deconvoltion
+  #           fusion_switch: "deconvolution", > for deconvolution
+  #           fusion_switch: "fusion", > for content based fusion
   # ============================================================================
-  #
   # Transformation switch:
-  transformation_switch: "timelapse", 
+  transformation_switch: "timelapse",
   # Fusion switch:
-  fusion_switch: "fusion",
+  fusion_switch: "deconvolution",
   # ============================================================================
   # xml file name
   # 
-  # xml file name without .xml suffix
+  # Description: xml file name without .xml suffix
   # ============================================================================
-  hdf5_xml_filename: '"single"', # Name of .xml file for the hdf5 data after resave_hdf5
-  # .xml file names for output
-  #output_xml: '"fused_Dpse_Dip3_VK33"',
-  #output_hdf5_xml: '"hdf5_fused_Dpse_Dip3_VK33"',
-  #
+  hdf5_xml_filename: '"single"', 
   # ============================================================================
   # Describe the dataset
   #
@@ -51,21 +48,22 @@ common: {
   #          angles
   #          channels
   #          illuminations
-  #          pixel size
+  #          Settings for .czi or .tif files
   # ============================================================================
   ntimepoints: 2,        # number of timepoints of dataset
-  angles: "0,72,144,216,288",   # angles "0,72,144,216,288"
-  channels: "green",     # channels, for tif numeric!
-  illumination: "0",     # illuminations
+  angles: "0,72,144,216,288",   # format e.g.: "0,72,144,216,288",
+  channels: "green",     # format e.g.: "green,red", IMPORTANT: for tif numeric!
+  illumination: "0",     # format e.g.: "0,1",
   # ----------------------------------------------------------------------------
-  # For .czi datasets
-  # master .czi file
+  # Settings for .czi files
   first_czi: "2015-02-21_LZ1_Stock68_3.czi", 
   # ----------------------------------------------------------------------------
-  # For .tif datasets
-  # file pattern of .tif files:
-  # for multi channel with one file per channel give spim_TL{tt}_Angle{a}_Channel{c}.tif
-  # for padded zeros use tt 
+  # Settings for .tif datasets
+  # Options: 
+  #          file pattern of .tif files:
+  #          multi channel with one file per channel: 
+  #          spim_TL{tt}_Angle{a}_Channel{c}.tif
+  #          for padded zeros use tt 
   image_file_pattern: 'img_TL{{t}}_Angle{{a}}.tif',
   multiple_channels: '"NO (one channel)"',         # '"YES (all channels in one file)"' or '"YES (one file per channel)"' or '"NO (one channel)"'
   # ============================================================================
@@ -73,6 +71,8 @@ common: {
   #
   # Description: settings for interest point detection and registration
   # Options: Single channel and dual channel processing
+  #          Source and traget for dual channel one channel contains the beads
+  #          Interestpoints label
   #          Difference-of-mean or difference-of-gaussian detection
   # ============================================================================
   # reg_process_channel:
@@ -124,21 +124,39 @@ common: {
   maximal_y: '1941',
   maximal_z: '486',
   # ============================================================================
+  # External transformation switch
+  #
+  # Description: Allows downsampling prior deconvolution
+  # Options: no downsampling 
+  #          external_trafo_switch: "_transform",
+  #
+  #          downsampling
+  #          external_trafo_switch: "external_trafo",
+  #          IMPORTANT: boundingbox needs to reflect this downsampling. 
+  #
+  #          Matrix for downsampling
+  # ============================================================================
+  # External transformation switch:
+  external_trafo_switch: "_transform",
+  #
+  # Matrix for downsampling
+  matrix_transform: '"0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0"',
+  # ============================================================================
   # Multiview deconvolution
   #
   # Description: settings for multiview deconvolution
-  # Options: number of iterations
-  #          Cropping parameters taking downsampling into account
+  # Options: 
+  #          number of iterations
+  #          Cropping parameters taking downsampling into account!
   #          Channel settings for deconvolution
   # ============================================================================
-  iterations: '1',        # number of iterations
-  minimal_x_deco: '190',  # Cropping parameters: take downsampling into account
-  minimal_y_deco: '-16',
-  minimal_z_deco: '-348',
-  maximal_x_deco: '1019',
-  maximal_y_deco: '1941',
-  maximal_z_deco: '486',
-  #
+  iterations: '2',        # number of iterations
+  minimal_x_deco: '95',  # Cropping parameters: take downsampling into account
+  minimal_y_deco: '-8',
+  minimal_z_deco: '-174',
+  maximal_x_deco: '509',
+  maximal_y_deco: '970',
+  maximal_z_deco: '243',
   # Channel settings for deconvolution
   # Single Channel: '"beads"'
   # Dual Channel: '"beads,beads"'
@@ -158,9 +176,9 @@ common: {
   # Calibration
   manual_calibration_output: "Yes", # calibration override: No or Yes
   # pixel size of output: take downsampling into account!
-  output_pixel_distance_x: 0.285901069641113, 
-  output_pixel_distance_y: 0.285901069641113,
-  output_pixel_distance_z: 0.285901069641113,
+  output_pixel_distance_x: 0.57, 
+  output_pixel_distance_y: 0.57,
+  output_pixel_distance_z: 0.57,
   output_pixel_unit: 'um'
   }
   # ============================================================================
@@ -276,17 +294,14 @@ fusion: {
 
 external_transform: {
   # Downsamples for deconvolution
-  # BUG: external transformation breaks .xml file
   # channel setting: '"all_channels"'
-  channel_setting: '"green"',
+  # channel_setting: '"green"',
   transform_timepoint: '"All Timepoints"',
   transform_angle: '"All angles"',
   transform_channel: '"All channels"',
   transform_illumination: '"All illuminations"',
   apply_transformation: '"Current view transformations (appends to current transforms)"',
   define_mode_transform: '"Matrix"',
-  # Matrix for downsampling
-  matrix_transform: '"0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0"',
   transformation: '"Rigid"',
   bsh_file: "transform.bsh"
   }
@@ -323,7 +338,7 @@ hdf5_output: {
   # subsampling_output: '"{{ {{1,1,1}}, {{2,2,2}} }}"',
   # chunk_sizes_output: '"{{ {{16,16,16}}, {{16,16,16}} }}"',
   # Standard settings for hdf5_output
-  output_type_of_dataset: '"Image Stacks (LOCI Bioformats)"', # '"Image Stacks (ImageJ Opener)"' or '"Image Stacks (LOCI Bioformats)"'
+  output_type_of_dataset: '"Image Stacks (ImageJ Opener)"', # '"Image Stacks (ImageJ Opener)"' or '"Image Stacks (LOCI Bioformats)"'
   output_multiple_timepoints: '"YES (one file per time-point)"',
   output_multiple_angles: '"NO (one angle)"',
   output_illumination_directions: '"NO (one illumination direction)"',

--- a/spim_registration/timelapse/config.yaml
+++ b/spim_registration/timelapse/config.yaml
@@ -155,19 +155,6 @@ common: {
   #          Pixel size > isotropic resolution
   #          Image type (16Bit from content-based fusion, 32Bit from deconvolution)
   # ============================================================================
-  # Number of timepoints
-  #output_timepoints: '0-1',   # Timepoints format: '1-2'
-  #
-  # Naming pattern:
-  # Single Channel: TP{{t}}_Chgreen_Ill0_Ang0,72,144,216,288.tif > Ch{name} is added here
-  # Dual Channel: TP{{t}}_Ch{{0}}_Ill0_Ang0,72,144,216,288.tif > Ch{name} is added here
-  #output_image_file_pattern: '"TP{{t}}_Ch0_Ill0_Ang1,2,3,4,5.tif"',
-  #
-  # channel setting:
-  # Single channel: '"NO (one channel)"'
-  # Dual channel: '"YES (one file per channel)"'
-  #output_multiple_channels: '"NO (one channel)"',
-  # output_channels: "green",
   # Calibration
   manual_calibration_output: "Yes", # calibration override: No or Yes
   # pixel size of output: take downsampling into account!

--- a/spim_registration/timelapse/config.yaml
+++ b/spim_registration/timelapse/config.yaml
@@ -35,16 +35,14 @@ common: {
   # Fusion switch:
   fusion_switch: "fusion",
   # ============================================================================
-  # xml file names
+  # xml file name
   # 
-  # xml file names without .xml suffix
+  # xml file name without .xml suffix
   # ============================================================================
-  #
-  first_xml_filename: 'Dpse_Dip3_VK33',              # Name of the xml file for the .czi or .tif files
-  hdf5_xml_filename: '"hdf5_Dpse_Dip3_VK33"', # Name of .xml file for the hdf5 data after resave_hdf5
+  hdf5_xml_filename: '"Dpse_Dip3_VK33"', # Name of .xml file for the hdf5 data after resave_hdf5
   # .xml file names for output
-  output_xml: '"fused_Dpse_Dip3_VK33"',
-  output_hdf5_xml: '"hdf5_fused_Dpse_Dip3_VK33"',
+  #output_xml: '"fused_Dpse_Dip3_VK33"',
+  #output_hdf5_xml: '"hdf5_fused_Dpse_Dip3_VK33"',
   #
   # ============================================================================
   # Describe the dataset
@@ -55,10 +53,10 @@ common: {
   #          illuminations
   #          pixel size
   # ============================================================================
-  ntimepoints: 2,               # number of timepoints of dataset
+  ntimepoints: 2,        # number of timepoints of dataset
   angles: "1,2,3,4,5",   # angles "0,72,144,216,288"
-  channels: "green",        # channels, for tif numeric!
-  illumination: "0",            # illuminations
+  channels: "green",     # channels, for tif numeric!
+  illumination: "0",     # illuminations
   # ----------------------------------------------------------------------------
   # For .czi datasets
   # master .czi file
@@ -84,6 +82,7 @@ common: {
   reg_process_channel: '"All channels"',
   #
   # Dual channel 1 Channel contains the beads: which channel contains the beads?
+  # Ignore if Single Channel or Dual Channel both channels contain beads
   reg_processing_channel: '"green"',
   #
   # reg_interest_points_channel:
@@ -109,7 +108,7 @@ common: {
   # Description: settings for timelapse registration
   # Options: reference timepoint
   # ============================================================================
-  reference_timepoint: '40',   # Reference timepoint
+  reference_timepoint: '1',   # Reference timepoint
   # ============================================================================
   # Content-based multiview fusion
   #
@@ -157,18 +156,18 @@ common: {
   #          Image type (16Bit from content-based fusion, 32Bit from deconvolution)
   # ============================================================================
   # Number of timepoints
-  output_timepoints: '0-1',   # Timepoints format: '1-2'
+  #output_timepoints: '0-1',   # Timepoints format: '1-2'
   #
   # Naming pattern:
   # Single Channel: TP{{t}}_Chgreen_Ill0_Ang0,72,144,216,288.tif > Ch{name} is added here
   # Dual Channel: TP{{t}}_Ch{{0}}_Ill0_Ang0,72,144,216,288.tif > Ch{name} is added here
-  output_image_file_pattern: '"TP{{t}}_Ch0_Ill0_Ang1,2,3,4,5.tif"',
+  #output_image_file_pattern: '"TP{{t}}_Ch0_Ill0_Ang1,2,3,4,5.tif"',
   #
   # channel setting:
   # Single channel: '"NO (one channel)"'
   # Dual channel: '"YES (one file per channel)"'
-  output_multiple_channels: '"NO (one channel)"',
-  output_channels: "green",
+  #output_multiple_channels: '"NO (one channel)"',
+  # output_channels: "green",
   # Calibration
   manual_calibration_output: "Yes", # calibration override: No or Yes
   # pixel size of output: take downsampling into account!

--- a/spim_registration/timelapse/define_output.bsh
+++ b/spim_registration/timelapse/define_output.bsh
@@ -140,7 +140,7 @@ String image_file_pattern = null;
 // channel string is necessary
 if (channel_token.length == 1)
 {
-        string_part_1 = "TP{t}_Ch0_";
+        string_part_1 = "TP{t}_Ch" + channels + "_";
 }
 
 else if (channel_token.length > 1)

--- a/spim_registration/timelapse/define_output.bsh
+++ b/spim_registration/timelapse/define_output.bsh
@@ -24,16 +24,13 @@ System.out.println( "xml_filename = " + xml_filename );
 // Dataset settings
 System.out.println("=========================================================");
 System.out.println("Dataset:");
-timepoints = System.getProperty( "timepoints" );
-image_file_pattern = System.getProperty( "image_file_pattern" );
+
 type_of_dataset = System.getProperty( "type_of_dataset" );
 multiple_timepoints = System.getProperty( "multiple_timepoints" );
 multiple_illumination_directions = System.getProperty( "multiple_illumination_directions" );
 multiple_angles = System.getProperty( "multiple_angles" );
 imglib_container = System.getProperty( "imglib_container" );
 
-System.out.println( "timepoints = " + timepoints );
-System.out.println( "image_file_pattern = " + image_file_pattern );
 System.out.println( "type_of_dataset = " + type_of_dataset );
 System.out.println( "multiple_timepoints = " + multiple_timepoints );
 System.out.println( "multiple_illumination_directions = " + multiple_illumination_directions );
@@ -56,25 +53,28 @@ System.out.println( "pixel_unit = " + pixel_unit );
 // Channel switch
 System.out.println("=========================================================");
 System.out.println("Channel Switch:");
-multiple_channels = System.getProperty( "multiple_channels" );
-System.out.println( "multiple_channels = " + multiple_channels );
-
+//multiple_channels = System.getProperty( "multiple_channels" );
 channels = System.getProperty( "channels" ); 
+// Parses string
+String delims = "[,]";
+String[] channel_token = channels.split(delims);
 
-if ( multiple_channels.equalsIgnoreCase( "NO (one channel)" ) )
+
+if ( channel_token.length ==1 )
 
 { 
 
-	channels="";
-
+	channels = "";
+	multiple_channels = "NO (one channel)";
 }
 
-else if ( multiple_channels.equalsIgnoreCase( "YES (one file per channel)" ) )
+else if ( channel_token.length > 1 )
 
 {
 
 	channels = "channels_=" + channels + " ";
-
+	multiple_channels = "YES (one file per channel)";
+	System.out.println( "channels = " + channels );
 }
 
 else {
@@ -82,6 +82,8 @@ else {
 	System.out.println( "Channel switch setting gibberish" );
 
 }
+
+System.out.println( "multiple_channels = " + multiple_channels );
 
 // Calibaration
 System.out.println("=========================================================");
@@ -118,9 +120,73 @@ else
 	System.out.println( "Manual calibration setting bad" );
 }
 
+// Assembles Image file pattern
+System.out.println("=========================================================");
+System.out.println("image_file_pattern:");
+illumination = System.getProperty( "illumination" );
+angles = System.getProperty( "angles" );
 
-System.out.println( "channels = " + channels );
+System.out.println( "illumination = " + illumination );
+System.out.println( "angles = " + angles );
 
+// Parses string illumination
+String[] illumination_token = illumination.split(delims);
+
+String string_part_1 = null;
+String string_part_2 = null;
+String image_file_pattern = null;
+
+// Decides based on the numbers of channels in parameter channels which
+// channel string is necessary
+if (channel_token.length == 1)
+{
+        string_part_1 = "TP{t}_Ch0_";
+}
+
+else if (channel_token.length > 1)
+{
+        string_part_1 = "TP{t}_Ch{c}_";
+}
+
+else
+{
+        System.out.println( "Channel Setting bad" );
+}
+
+// Decides based on the numbers of illuminations in parameter illumination which
+// illumination string is necessary
+if (illumination_token.length == 1)
+{
+        string_part_2 = "Ill0_";
+}
+
+else if (illumination_token.length > 1)
+{
+        string_part_2 = "Ill{i}_";
+}
+
+else
+{
+        System.out.println( "Illumination Setting bad" );
+}
+
+// Puts together the string for image_file_pattern
+image_file_pattern = string_part_1 + string_part_2 + "Ang" + angles +".tif";
+
+System.out.println( image_file_pattern );
+
+System.out.println("=========================================================");
+System.out.println("time points setting:");
+
+int ntimepoints = Integer.parseInt(System.getProperty("ntimepoints" ) );
+
+int last_timepoint = ntimepoints - 1;
+String timepoints = "0-" + last_timepoint;
+
+System.out.println( "timepoints = " + timepoints );
+
+System.out.println("=========================================================");
+System.out.println("Start plugin:");
 System.out.println("Define Multi-View Dataset , type_of_dataset=[" + type_of_dataset + "] " +
 	"xml_filename=[" + xml_filename + ".xml] " +
 	"multiple_timepoints=[" + multiple_timepoints + "] " +
@@ -138,8 +204,6 @@ System.out.println("Define Multi-View Dataset , type_of_dataset=[" + type_of_dat
 	"");
 
 // Executes Fiji plugin
-System.out.println("=========================================================");
-System.out.println("Start plugin:");
 try {
 IJ.run("Define Multi-View Dataset", 
 	"type_of_dataset=[" + type_of_dataset + "] " +

--- a/spim_registration/timelapse/define_output.bsh
+++ b/spim_registration/timelapse/define_output.bsh
@@ -123,11 +123,14 @@ else
 // Assembles Image file pattern
 System.out.println("=========================================================");
 System.out.println("image_file_pattern:");
-illumination = System.getProperty( "illumination" );
+channel_name = System.getProperty( "channels" ); 
 angles = System.getProperty( "angles" );
+illumination = System.getProperty( "illumination" );
 
-System.out.println( "illumination = " + illumination );
+System.out.println( "channel_name =" + channel_name );
 System.out.println( "angles = " + angles );
+System.out.println( "illumination = " + illumination );
+
 
 // Parses string illumination
 String[] illumination_token = illumination.split(delims);
@@ -140,7 +143,7 @@ String image_file_pattern = null;
 // channel string is necessary
 if (channel_token.length == 1)
 {
-        string_part_1 = "TP{t}_Ch" + channels + "_";
+        string_part_1 = "TP{t}_Ch" + channel_name + "_";
 }
 
 else if (channel_token.length > 1)

--- a/spim_registration/timelapse/define_tif_zip.bsh
+++ b/spim_registration/timelapse/define_tif_zip.bsh
@@ -113,10 +113,10 @@ System.out.println( "Illuminations = " + illum_string );
 System.out.println("=========================================================");
 System.out.println("Calibration:");
 manual_calibration_tif = System.getProperty( "manual_calibration_tif" );
-float czi_pixel_distance_x = Float.parseFloat( System.getProperty( "pixel_distance_x" ) );
-float czi_pixel_distance_y = Float.parseFloat( System.getProperty( "pixel_distance_y" ) );
-float czi_pixel_distance_z = Float.parseFloat( System.getProperty( "pixel_distance_z" ) );
-czi_pixel_unit = System.getProperty( "pixel_unit" );
+float pixel_distance_x = Float.parseFloat( System.getProperty( "pixel_distance_x" ) );
+float pixel_distance_y = Float.parseFloat( System.getProperty( "pixel_distance_y" ) );
+float pixel_distance_z = Float.parseFloat( System.getProperty( "pixel_distance_z" ) );
+pixel_unit = System.getProperty( "pixel_unit" );
 
 // builds string for calibration override
 if (manual_calibration_tif.equalsIgnoreCase( "No" ) )

--- a/spim_registration/timelapse/export_output.bsh
+++ b/spim_registration/timelapse/export_output.bsh
@@ -84,6 +84,22 @@ catch ( e ) {
 // Executes Fiji plugin
 System.out.println("=========================================================");
 System.out.println("Start plugin:");
+System.out.println("As HDF5, select_xml=" + image_file_directory + first_xml_filename + ".xml " +
+	"resave_angle=[" + resave_angle + "] " +
+	"resave_channel=[" + resave_channel + "] " +
+	"resave_illumination=[" + resave_illumination + "] " +
+	"resave_timepoint=[" + resave_timepoint + "] " +
+	"manual_mipmap_setup " +
+	"subsampling_factors=[" + subsampling_factors + "] " +
+	"hdf5_chunk_sizes=[" + hdf5_chunk_sizes + "] " +
+	"split_hdf5 " +
+	"timepoints_per_partition=" + timepoints_per_partition + " " +
+	"setups_per_partition=" + setups_per_partition + " " +
+	"run_only_job_number=" + run_only_job_number + " " +
+	"use_deflate_compression " +
+	"export_path=" + image_file_directory + hdf5_xml_filename + " " +
+	data_string + "");
+
 try{
 IJ.run("As HDF5",
 	"select_xml=" + image_file_directory + first_xml_filename + ".xml " +

--- a/spim_registration/timelapse/transform.bsh
+++ b/spim_registration/timelapse/transform.bsh
@@ -17,7 +17,6 @@ transform_angle = System.getProperty( "transform_angle" );
 transform_channel = System.getProperty( "transform_channel" );
 transform_illumination = System.getProperty( "transform_illumination" );
 transform_timepoint = System.getProperty( "transform_timepoint" );
-channel_setting = System.getProperty( "channel_setting" );
 transformation = System.getProperty( "transformation" );
 apply_transformation  = System.getProperty( "apply_transformation" );
 define_mode_transform = System.getProperty( "define_mode_transform" );
@@ -31,11 +30,63 @@ System.out.println( "apply_to_angle = " + transform_angle );
 System.out.println( "apply_to_channel = " + transform_channel );
 System.out.println( "apply_to_illumination = " + transform_illumination );
 System.out.println( "apply_to_timepoint = " + transform_timepoint );
-System.out.println( "Channel_setting = " + channel_setting );
 System.out.println( "transformation = " + transformation );
 System.out.println( "apply = " + apply_transformation );
 System.out.println( "define = " + define_mode_transform );
-System.out.println( "all_timepoints_channel_" + channel_setting + "_illumination_0_all_angles = " + matrix_transform );
+
+// Prints channel settings:
+channel_setting = System.getProperty( "channel_setting" );
+System.out.println( "Channel_setting = " + channel_setting );
+
+String delims = "[,]";
+String[] channel_token = channel_setting.split(delims);
+
+if ( channel_token.length ==1 )
+
+{ 
+
+	channels_string = "_" + channel_setting;
+	System.out.println("channels = " + channels_string);
+	multiple_channels = "NO (one channel)";
+}
+
+else if ( channel_token.length > 1 )
+
+{
+
+	channels = "";
+	multiple_channels = "YES (one file per channel)";
+	
+}
+
+System.out.println( "channels = " + multiple_channels );
+
+
+// Prints illumination settings:
+illumination = System.getProperty( "illumination" );
+
+String[] illumination_token = illumination.split(delims);
+
+if ( illumination_token.length ==1 )
+
+{ 
+
+	illumination_string = "_" + illumination;
+	System.out.println("illumination = " + illumination_string);
+	multiple_illumination = "NO (one illumination side)";
+}
+
+else if ( channel_token.length > 1 )
+
+{
+
+	illumination = "";
+	multiple_illumination = "YES (one file per illumination)";
+	
+}
+
+System.out.println( "illumination = " + multiple_illumination );
+
 
 // Execute Fiji Plugin
 try {
@@ -51,7 +102,7 @@ IJ.run("Apply Transformations",
 	"define=" + define_mode_transform + " " + 
 	"same_transformation_for_all_timepoints " + 
 	"same_transformation_for_all_angles " +
-	"all_timepoints_channel_" + channel_setting + "_illumination_0_all_angles=[" + matrix_transform + "]");
+	"all_timepoints_channel" + channels_string + "_illumination" + illumination_string + "_all_angles=[" + matrix_transform + "]");
 }
 catch ( e ) { 
 


### PR DESCRIPTION
Tested and works

The xml names for intermediate processing steps (i.e define_xml_czi, define_xml_tif and define_output) are now defined in the snakefile. 

The name for the final product is assembled from hdf5_xml_filename and the setting in fusion_switch.
Giving the output an identity based on the final processing. 

Simplified the define output settings by assembling the string for the file name pattern in the define_output.bsh script. 

Settings for calibration are prepared for automatic readout from the file metadata, but there is a bug in the ouput: the metadata is not saved in the final .tifs. 
